### PR TITLE
[ci skip] adding user @karajan1001

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @efiop @pmrowla @shcheklein
+* @karajan1001 @efiop @pmrowla @shcheklein

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - karajan1001
     - pmrowla
     - efiop
     - shcheklein


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @karajan1001 as instructed in #8.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #8